### PR TITLE
fix: Handle e2e secret variables

### DIFF
--- a/src/test/resources/setup.sh
+++ b/src/test/resources/setup.sh
@@ -35,6 +35,12 @@ if [ -z "${OPENSHIFT_MASTER}" ]; then
     OPENSHIFT_MASTER="$(oc whoami --show-server)"
 fi
 
+#Configure the SYNDESIS_E2E_SECRET
+if [ -z ${SYNDESIS_E2E_SECRET} ]; then
+    GITHUB_OAUTH_CLIENT_ID=${GITHUB_E2E_OAUTH_CLIENT_ID}
+    GITHUB_OAUTH_CLIENT_SECRET=${GITHUB_E2E_OAUTH_CLIENT_SECRET}
+fi
+
 # We pass the namespace on each command individually, because when this script is run inside a pod, all commands default to the pod namespace (ignoring commands like `oc project` etc)
 echo "Installing Syndesis in ${KUBERNETES_NAMESPACE} from: ${SYNDESIS_TEMPLATE_URL}"
 oc project ${KUBERNETES_NAMESPACE}


### PR DESCRIPTION
@iocanel as we've discussed earlier, probably 2 weeks ago. I wanted to overwrite env variables through `scriptEnvironmentVariables:` parameter of `createEnvironment()` method in Jenkins pipeline, but without success. 

Would you mind adding such a switch to setup script for now? This enables e2e pipeline to use correct clientId and secret that is bound with callback URL, so tests can successfully login in automated fashion. If I should make it a bit more future-proof or if it's horrible idea :), let me know.
